### PR TITLE
Uses html & mocha reporters for Karma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Test reports
+client/test/reports
+
 # Logs
 logs
 *.log

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,21 @@ module.exports = function (config) {
     ],
     exclude: [],
     preprocessors: {},
-    reporters: ['progress'],
+
+    reporters: ['mocha', 'html'],
+
+    mochaReporter: { // info at https://github.com/litixsoft/karma-mocha-reporter
+      output: 'autowatch'
+    },
+
+    htmlReporter: { // info at https://github.com/dtabuenc/karma-html-reporter
+      outputDir: 'client/test/reports',
+      namedFiles: true,
+      pageTitle: 'Dojo App Specs',
+      urlFriendlyName: true,
+      reportName: 'spec-results'
+    },
+
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,8 @@ module.exports = function (config) {
       namedFiles: true,
       pageTitle: 'Dojo App Specs',
       urlFriendlyName: true,
-      reportName: 'spec-results'
+      reportName: 'spec-results',
+      preserveDescribeNesting: true
     },
 
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "jscs": "^3.0.7",
     "jshint": "^2.9.2",
     "karma": "^1.1.2",
+    "karma-html-reporter": "^0.2.7",
     "karma-jasmine": "^1.0.2",
+    "karma-mocha-reporter": "^2.1.0",
     "karma-phantomjs-launcher": "^1.0.1",
     "phantomjs-prebuilt": "^2.1.8"
   },


### PR DESCRIPTION
This is how _mocha_ reports on console now:
![image](https://cloud.githubusercontent.com/assets/4429577/17458665/08f4ecf0-5bf0-11e6-99f6-8d21bb48a782.png)
Better to debug:
![image](https://cloud.githubusercontent.com/assets/4429577/17458689/0a791bfe-5bf1-11e6-82f1-522a55e231c2.png)

And _html_ reporter:
![image](https://cloud.githubusercontent.com/assets/4429577/17458712/80783632-5bf1-11e6-95e4-e8a6f782becd.png)

Closes #1 
